### PR TITLE
cannot log to stdout

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -247,7 +247,7 @@ async function runServer() {
   try {
     const transport = new StdioServerTransport();
     await server.connect(transport);
-    console.log("MCP Maps Server started");
+    console.error("MCP Maps Server started");
   } catch (error) {
     console.error("Server startup failed:", error);
     process.exit(1);


### PR DESCRIPTION
## Fix: Change console.log to console.error to prevent MCP protocol breakage

### Problem
The MCP (Model Context Protocol) server is currently outputting a plain text message to stdout using `console.log()`, which breaks the JSON-RPC protocol communication. This causes the following error in Claude Desktop:

```
Unexpected token 'M', "MCP Maps S"... is not valid JSON
```

### Root Cause
MCP uses stdio for communication where:
- **stdout** must contain ONLY valid JSON-RPC messages
- **stderr** should be used for debugging/logging output

When the server prints `"MCP Maps Server started"` to stdout, it corrupts the JSON-RPC message stream, causing the client to fail when parsing the output.

### Solution
Changed `console.log()` to `console.error()` on line 250 to redirect the startup message to stderr instead of stdout.

### Testing
- Verified the server starts without JSON parsing errors
- Confirmed the startup message still appears in logs (via stderr)
- Tested that all MCP tools remain functional after the change

This is a critical fix that ensures compatibility with the MCP protocol specification and prevents communication failures between the server and clients like Claude Desktop.