### PR TITLE
fix: create per-session McpServer to prevent multi-session crash

### DIFF
--- a/src/core/BaseMcpServer.ts
+++ b/src/core/BaseMcpServer.ts
@@ -29,29 +29,23 @@ export class BaseMcpServer {
   private sessions: { [sessionId: string]: SessionContext } = {};
   private httpServer: Server | null = null;
   private serverName: string;
+  private tools: ToolConfig[];
 
   constructor(name: string, tools: ToolConfig[]) {
     this.serverName = name;
-    this.server = new McpServer(
-      {
-        name: this.serverName,
-        version: VERSION,
-      },
-      {
-        capabilities: {
-          logging: {},
-          tools: {},
-        },
-      }
-    );
-
-    this.registerTools(tools);
+    this.tools = tools;
+    this.server = this.createMcpServer();
   }
 
-  private registerTools(tools: ToolConfig[]): void {
-    tools.forEach((tool) => {
-      this.server.tool(tool.name, tool.description, tool.schema, async (params: any) => tool.action(params));
+  private createMcpServer(): McpServer {
+    const server = new McpServer(
+      { name: this.serverName, version: VERSION },
+      { capabilities: { logging: {}, tools: {} } }
+    );
+    this.tools.forEach((tool) => {
+      server.tool(tool.name, tool.description, tool.schema, async (params: any) => tool.action(params));
     });
+    return server;
   }
 
   async connect(transport: Transport): Promise<void> {
@@ -119,7 +113,8 @@ export class BaseMcpServer {
           }
         };
 
-        await this.server.connect(transport);
+        const sessionServer = this.createMcpServer();
+        await sessionServer.connect(transport);
       } else {
         // Invalid request
         res.status(400).json({


### PR DESCRIPTION
## Summary

- **Fixes #27** — Server crashes with "Already connected to a transport" when a second HTTP session connects
- Creates a new `McpServer` instance per HTTP session instead of reusing a singleton; tools are replayed from stored config
- Stdio mode unchanged (uses the singleton as before — 1:1 by nature)

## Changes

Single file: `src/core/BaseMcpServer.ts` (+13 / -18 lines)

- Store `tools: ToolConfig[]` on the class for replay
- Extract `createMcpServer()` factory method
- HTTP path calls `createMcpServer()` per session instead of `this.server.connect(transport)`

## Test plan

- [ ] Start server in HTTP mode (`mcp-google-map --port 3020`)
- [ ] Send first `initialize` request → should succeed
- [ ] Send second `initialize` request → should succeed (previously crashed)
- [ ] Verify stdio mode still works (`mcp-google-map` without `--port`)
- [ ] Verify tools respond correctly on both sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)