### PR TITLE
feat: auto-publish to MCP Registry on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -63,12 +64,23 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+      - name: Sync server.json version
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          jq --arg v "$VERSION" '.version = $v | .packages[0].version = $v' server.json > server.tmp && mv server.tmp server.json
+
+      - name: Publish to MCP Registry
+        run: |
+          curl -sL "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_linux_amd64.tar.gz" | tar xz mcp-publisher
+          ./mcp-publisher login github-oidc
+          ./mcp-publisher publish
+
       - name: Commit version bump & tag
         run: |
           VERSION=$(node -p "require('./package.json').version")
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add package.json package-lock.json CHANGELOG.md
+          git add package.json package-lock.json CHANGELOG.md server.json
           git commit -m "chore: release v${VERSION}"
           git tag "v${VERSION}"
           git push


### PR DESCRIPTION
## Summary

- Add MCP Registry publish step to release workflow (runs after npm publish)
- Auto-sync `server.json` version from `package.json` before publishing
- Use GitHub OIDC auth — no extra secrets needed, just `id-token: write` permission
- Include `server.json` in the version bump commit so it stays in sync

## Flow

```
npm publish → sync server.json version → mcp-publisher login (OIDC) → mcp-publisher publish → git commit + tag
```

## Test plan

- [x] Manual `mcp-publisher publish` verified working (v0.0.26 live on registry)
- [ ] CI workflow triggers on next merge to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)