### PR TITLE
fix: add concurrency to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: release
+  cancel-in-progress: false
+
 jobs:
   release:
     # Skip automated version bump commits


### PR DESCRIPTION
## Summary

Add `concurrency` group to release workflow to prevent race conditions when multiple PRs merge in quick succession.

**Problem**: PR #36 and #37 merged close together → two release jobs ran in parallel → #36's `git push` was rejected because #37 already pushed, and #37's `npm publish` failed because #36 already published the same version.

**Fix**: `concurrency: { group: release, cancel-in-progress: false }` — release jobs queue instead of running concurrently.

## Test plan

- [x] No functional changes — workflow config only
- [ ] Next consecutive merge will queue instead of race

🤖 Generated with [Claude Code](https://claude.com/claude-code)