### PR TITLE
fix: sync version to 0.0.28 to match npm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cablate/mcp-google-map",
-  "version": "0.0.27",
+  "version": "0.0.28",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@cablate/mcp-google-map",
-      "version": "0.0.27",
+      "version": "0.0.28",
       "license": "MIT",
       "dependencies": {
         "@googlemaps/google-maps-services-js": "^3.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cablate/mcp-google-map",
-  "version": "0.0.27",
+  "version": "0.0.28",
   "mcpName": "io.github.cablate/google-map",
   "description": "Google Maps tools for AI agents — geocode, search, directions, elevation via MCP server or standalone CLI",
   "type": "module",


### PR DESCRIPTION
## Summary

Race condition from PR #36/#37 caused npm to publish 0.0.28 but the version bump commit failed to push back to main. Repo is stuck at 0.0.27, so every new release tries to publish 0.0.28 again and fails.

This syncs the repo version to 0.0.28. Next release will bump to 0.0.29 correctly.

## Test plan

- [x] `npm view @cablate/mcp-google-map version` → 0.0.28 (already published)
- [ ] Next merge to main will release 0.0.29 successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)