### PR TITLE
docs: rewrite README header with value proposition and comparison table

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,6 @@
 
 [<img src="https://img.shields.io/badge/VS_Code-VS_Code?style=flat-square&label=Install%20Server&color=0098FF" alt="Install in VS Code">](https://insiders.vscode.dev/redirect?url=vscode%3Amcp%2Finstall%3F%257B%2522name%2522%253A%2522google-maps%2522%252C%2522command%2522%253A%2522npx%2522%252C%2522args%2522%253A%255B%2522-y%2522%252C%2522%2540cablate%252Fmcp-google-map%2540latest%2522%252C%2522--stdio%2522%255D%252C%2522env%2522%253A%257B%2522GOOGLE_MAPS_API_KEY%2522%253A%2522YOUR_API_KEY%2522%257D%257D) [<img alt="Install in VS Code Insiders" src="https://img.shields.io/badge/VS_Code_Insiders-VS_Code_Insiders?style=flat-square&label=Install%20Server&color=24bfa5">](https://insiders.vscode.dev/redirect?url=vscode-insiders%3Amcp%2Finstall%3F%257B%2522name%2522%253A%2522google-maps%2522%252C%2522command%2522%253A%2522npx%2522%252C%2522args%2522%253A%255B%2522-y%2522%252C%2522%2540cablate%252Fmcp-google-map%2540latest%2522%252C%2522--stdio%2522%255D%252C%2522env%2522%253A%257B%2522GOOGLE_MAPS_API_KEY%2522%253A%2522YOUR_API_KEY%2522%257D%257D)
 
-<a href="https://glama.ai/mcp/servers/@cablate/mcp-google-map">
-  <img width="380" height="200" src="https://glama.ai/mcp/servers/@cablate/mcp-google-map/badge" alt="Google Map Server MCP server" />
-</a>
-
 # MCP Google Map Server
 
 Give your AI agent the ability to understand the physical world — geocode, route, search, and reason about locations.
@@ -261,5 +257,9 @@ Community participation and contributions are welcome!
 - GitHub: [CabLate](https://github.com/cablate/)
 
 ## Star History
+
+<a href="https://glama.ai/mcp/servers/@cablate/mcp-google-map">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@cablate/mcp-google-map/badge" alt="Google Map Server MCP server" />
+</a>
 
 [![Star History Chart](https://api.star-history.com/svg?repos=cablate/mcp-google-map&type=Date)](https://www.star-history.com/#cablate/mcp-google-map&Date)


### PR DESCRIPTION
## Summary

Rewrite the first ~30 lines of README for stronger first impression:

- **One-liner**: "Give your AI agent the ability to understand the physical world"
- **3-bullet highlights**: 8 tools, 3 modes, Agent Skill
- **vs Grounding Lite table**: side-by-side comparison showing our 8 tools vs their 3
- **Quick Start**: all 3 modes (stdio, exec, HTTP) in one block
- Remove verbose "Important Notice" box and "Verified Compatibility" section

Rest of README unchanged.

## Preview

The header now answers three questions immediately:
1. What does it do? → one-liner
2. Why choose this over Google's? → comparison table
3. How do I start? → 3-line quick start

🤖 Generated with [Claude Code](https://claude.com/claude-code)