### PR TITLE
refactor!: unify tool namespace to maps_* prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ Special thanks to [@junyinnnn](https://github.com/junyinnnn) for helping add sup
 
 | Tool | Description |
 |------|-------------|
-| `search_nearby` | Find places near a location by type (restaurant, cafe, hotel, etc.). Supports filtering by radius, rating, and open status. |
+| `maps_search_nearby` | Find places near a location by type (restaurant, cafe, hotel, etc.). Supports filtering by radius, rating, and open status. |
 | `maps_search_places` | Free-text place search (e.g., "sushi restaurants in Tokyo"). Supports location bias, rating, open-now filters. |
-| `get_place_details` | Get full details for a place by its place_id — reviews, phone, website, hours, photos. |
+| `maps_place_details` | Get full details for a place by its place_id — reviews, phone, website, hours, photos. |
 | `maps_geocode` | Convert an address or landmark name into GPS coordinates. |
 | `maps_reverse_geocode` | Convert GPS coordinates into a street address. |
 | `maps_distance_matrix` | Calculate travel distances and times between multiple origins and destinations. |
@@ -200,9 +200,9 @@ src/
 │   └── toolclass.ts              # Legacy Google Maps API client
 ├── tools/
 │   └── maps/
-│       ├── searchNearby.ts       # search_nearby tool
+│       ├── searchNearby.ts       # maps_search_nearby tool
 │       ├── searchPlaces.ts       # maps_search_places tool
-│       ├── placeDetails.ts       # get_place_details tool
+│       ├── placeDetails.ts       # maps_place_details tool
 │       ├── geocode.ts            # maps_geocode tool
 │       ├── reverseGeocode.ts     # maps_reverse_geocode tool
 │       ├── distanceMatrix.ts     # maps_distance_matrix tool

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -102,6 +102,7 @@ async function execTool(toolName: string, params: any, apiKey: string): Promise<
 
     case "search-nearby":
     case "search_nearby":
+    case "maps_search_nearby":
       return searcher.searchNearby(params);
 
     case "search-places":
@@ -116,6 +117,7 @@ async function execTool(toolName: string, params: any, apiKey: string): Promise<
 
     case "place-details":
     case "get_place_details":
+    case "maps_place_details":
       return searcher.getPlaceDetails(params.placeId);
 
     case "directions":

--- a/src/tools/maps/placeDetails.ts
+++ b/src/tools/maps/placeDetails.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import { PlacesSearcher } from "../../services/PlacesSearcher.js";
 import { getCurrentApiKey } from "../../utils/requestContext.js";
 
-const NAME = "get_place_details";
+const NAME = "maps_place_details";
 const DESCRIPTION =
   "Get comprehensive details for a specific place using its Google Maps place_id. Use after search_nearby or maps_search_places to get full information including reviews, phone number, website, opening hours, and photos. Returns everything needed to evaluate or contact a business.";
 

--- a/src/tools/maps/searchNearby.ts
+++ b/src/tools/maps/searchNearby.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import { PlacesSearcher } from "../../services/PlacesSearcher.js";
 import { getCurrentApiKey } from "../../utils/requestContext.js";
 
-const NAME = "search_nearby";
+const NAME = "maps_search_nearby";
 const DESCRIPTION =
   "Find places near a specific location by type (e.g., restaurants, cafes, hotels). Use when the user wants to discover what's around a given address or coordinates, such as 'find coffee shops near Times Square' or 'what hotels are near the airport'. Supports filtering by place type, search radius, minimum rating, and whether currently open.";
 

--- a/tests/smoke.test.ts
+++ b/tests/smoke.test.ts
@@ -200,8 +200,8 @@ async function testListTools(session: McpSession): Promise<void> {
 
   const toolNames = tools.map((t: any) => t.name);
   const expectedTools = [
-    "search_nearby",
-    "get_place_details",
+    "maps_search_nearby",
+    "maps_place_details",
     "maps_geocode",
     "maps_reverse_geocode",
     "maps_distance_matrix",
@@ -313,7 +313,7 @@ async function testToolCalls(session: McpSession): Promise<void> {
 
   // Test search_nearby (uses Places API New)
   const nearbyResult = await sendRequest(session, "tools/call", {
-    name: "search_nearby",
+    name: "maps_search_nearby",
     arguments: {
       center: { value: "35.6586,139.7454", isCoordinates: true },
       keyword: "restaurant",


### PR DESCRIPTION
## Summary

**BREAKING CHANGE**: Rename 2 tools for consistent `maps_*` namespace:

| Before | After |
|--------|-------|
| `search_nearby` | `maps_search_nearby` |
| `get_place_details` | `maps_place_details` |

All 10 tools now follow the same `maps_*` naming convention. CLI exec mode still accepts old names for backwards compatibility.

## Test plan

- [x] `npm run build` passes
- [x] `npm test` — 94 passed, 0 failed
- [x] README updated with new names
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)