### PR TITLE
fix: shorten server.json description for MCP Registry

### DIFF
--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.cablate/google-map",
   "title": "Google Maps MCP Server",
-  "description": "Google Maps tools for AI agents — geocode, search, directions, elevation. stdio + HTTP.",
+  "description": "17 Google Maps tools for AI agents — geocode, search, directions, weather, air quality, and more.",
   "repository": {
     "url": "https://github.com/cablate/mcp-google-map",
     "source": "github"
@@ -23,6 +23,13 @@
           "isRequired": true,
           "format": "string",
           "isSecret": true
+        },
+        {
+          "name": "GOOGLE_MAPS_ENABLED_TOOLS",
+          "description": "Comma-separated tool names to enable. Omit or * for all 17 tools.",
+          "isRequired": false,
+          "format": "string",
+          "isSecret": false
         }
       ]
     }


### PR DESCRIPTION
## Summary

PR#53 merge 後 Release CI 在 `Publish to MCP Registry` 步驟失敗：

```
expected length <= 100, location: body.description, value: "17 Google Maps tools..." (125 chars)
```

## Changes

- **server.json**: description 從 125 → 99 字元（移除 "map images, and more. stdio + HTTP."）
- 新增 `GOOGLE_MAPS_ENABLED_TOOLS` 環境變數宣告

## Test plan

- [x] Description length: 99 chars (under 100 limit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)