### PR TITLE
chore: release v0.0.41

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.0.41
+
+- docs: add hero banner + badges to README (#56)
+- docs: add demo screenshots + Chinese README + language switcher (#55)
+- fix: shorten server.json description to fit MCP Registry 100-char limit (#54)
+- chore: update server.json and package.json descriptions (#53)
+
 ## 0.0.39
 
 - fix: align skill tool names with actual MCP names (#52)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cablate/mcp-google-map",
-  "version": "0.0.39",
+  "version": "0.0.41",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@cablate/mcp-google-map",
-      "version": "0.0.39",
+      "version": "0.0.41",
       "license": "MIT",
       "dependencies": {
         "@googlemaps/google-maps-services-js": "^3.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cablate/mcp-google-map",
-  "version": "0.0.39",
+  "version": "0.0.41",
   "mcpName": "io.github.cablate/google-map",
   "description": "17 Google Maps tools for AI agents — geocode, search, directions, weather, air quality, map images via MCP server or standalone CLI",
   "type": "module",


### PR DESCRIPTION
## Summary
- Bump version to 0.0.41 (0.0.40 already published on npm, causing CI failure)
- Update CHANGELOG with PR #53–#56

## Test plan
- [ ] CI passes
- [ ] npm publish succeeds with 0.0.41

🤖 Generated with [Claude Code](https://claude.com/claude-code)