### PR TITLE
fix: trigger release pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - docs: add hero banner + badges to README (#56)
 - docs: add demo screenshots + Chinese README + language switcher (#55)
 - fix: shorten server.json description to fit MCP Registry 100-char limit (#54)
-- chore: update server.json and package.json descriptions (#53)
+- chore: update descriptions (#53)
 
 ## 0.0.39
 


### PR DESCRIPTION
## Summary
- PR#57 commit message contained `chore: release` which matched the skip guard in release.yml, causing the release job to be skipped
- This PR triggers the release pipeline to publish v0.0.42

🤖 Generated with [Claude Code](https://claude.com/claude-code)