### PR TITLE
fix: shorten server.json description for MCP Registry

### DIFF
--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.cablate/google-map",
   "title": "Google Maps MCP Server",
-  "description": "18 Google Maps tools for AI agents — geocode, search, directions, weather, air quality, local rank tracking, and more.",
+  "description": "18 Google Maps tools for AI agents — geocode, search, directions, weather, and more.",
   "repository": {
     "url": "https://github.com/cablate/mcp-google-map",
     "source": "github"


### PR DESCRIPTION
## Summary
- MCP Registry requires `description` <= 100 characters
- Current: 120 chars (added "air quality, local rank tracking" in #65)
- Fixed: 86 chars — removed specific tool names, kept "and more."

## Test plan
- [x] Description under 100 chars
- [ ] Release workflow publishes to MCP Registry successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)