### PR TITLE
chore: sync package.json version to 0.0.48

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cablate/mcp-google-map",
-  "version": "0.0.47",
+  "version": "0.0.48",
   "mcpName": "io.github.cablate/google-map",
   "description": "18 Google Maps tools for AI agents — geocode, search, directions, weather, air quality, local rank tracking, map images via MCP server or standalone CLI",
   "type": "module",


### PR DESCRIPTION
## Summary
- Previous release published 0.0.48 to npm but failed at MCP Registry step
- The version bump commit never landed on main (package.json still says 0.0.47)
- This syncs package.json to 0.0.48 so the next release will correctly bump to 0.0.49

**Note**: Commit message starts with `chore: release` so the release workflow will skip this merge (matching the existing skip condition).

## Test plan
- [x] Next merge to main won't trigger release (skipped by `chore: release` prefix)
- [ ] Next feature merge will bump to 0.0.49 and publish successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)