### PR TITLE
fix: include transitDetails in Routes API field mask

### DIFF
--- a/src/services/RoutesService.ts
+++ b/src/services/RoutesService.ts
@@ -25,6 +25,7 @@ const COMPUTE_ROUTES_FIELD_MASK = [
   "routes.legs.steps.staticDuration",
   "routes.legs.steps.startLocation",
   "routes.legs.steps.endLocation",
+  "routes.legs.steps.transitDetails",
   "routes.legs.polyline",
   "routes.optimizedIntermediateWaypointIndex",
 ].join(",");

--- a/src/tools/maps/directions.ts
+++ b/src/tools/maps/directions.ts
@@ -15,7 +15,10 @@ const SCHEMA = {
     .describe("Travel mode for directions"),
   departure_time: z.string().optional().describe("Departure time (ISO string format)"),
   arrival_time: z.string().optional().describe("Arrival time (ISO string format)"),
-  avoid_tolls: z.boolean().optional().describe('Avoid toll roads where reasonable. Only supported with mode "driving".'),
+  avoid_tolls: z
+    .boolean()
+    .optional()
+    .describe('Avoid toll roads where reasonable. Only supported with mode "driving".'),
   avoid_highways: z
     .boolean()
     .optional()

--- a/src/tools/maps/distanceMatrix.ts
+++ b/src/tools/maps/distanceMatrix.ts
@@ -19,7 +19,10 @@ const SCHEMA = {
     .describe(
       "Departure time in ISO 8601 format (e.g. 2026-03-21T09:00:00Z). Enables traffic-aware duration estimates."
     ),
-  avoid_tolls: z.boolean().optional().describe('Avoid toll roads where reasonable. Only supported with mode "driving".'),
+  avoid_tolls: z
+    .boolean()
+    .optional()
+    .describe('Avoid toll roads where reasonable. Only supported with mode "driving".'),
   avoid_highways: z
     .boolean()
     .optional()

--- a/src/tools/maps/planRoute.ts
+++ b/src/tools/maps/planRoute.ts
@@ -19,7 +19,10 @@ const SCHEMA = {
     .string()
     .optional()
     .describe("Departure time in ISO 8601 format (e.g. 2026-03-21T09:00:00Z). Enables traffic-aware routing."),
-  avoid_tolls: z.boolean().optional().describe('Avoid toll roads where reasonable. Only supported with mode "driving".'),
+  avoid_tolls: z
+    .boolean()
+    .optional()
+    .describe('Avoid toll roads where reasonable. Only supported with mode "driving".'),
   avoid_highways: z
     .boolean()
     .optional()

--- a/tests/smoke.test.ts
+++ b/tests/smoke.test.ts
@@ -1136,9 +1136,7 @@ async function testTransitDetailsField(session: McpSession): Promise<void> {
   const transitStep = steps.find((s: any) => s.transitDetails);
   if (!transitStep) {
     // Routes API may rarely return a walking-only itinerary; warn but don't flaky-fail.
-    console.log(
-      "  ⚠️  No transit step in this itinerary — field mask correctness cannot be asserted this run"
-    );
+    console.log("  ⚠️  No transit step in this itinerary — field mask correctness cannot be asserted this run");
     return;
   }
 

--- a/tests/smoke.test.ts
+++ b/tests/smoke.test.ts
@@ -1103,6 +1103,53 @@ async function testTransitErrorMessages(session: McpSession): Promise<void> {
   }
 }
 
+async function testTransitDetailsField(session: McpSession): Promise<void> {
+  if (!API_KEY) {
+    console.log("  ⏭️  Skipped transitDetails test (no GOOGLE_MAPS_API_KEY)");
+    return;
+  }
+
+  console.log("\n🔍 Testing transit step includes transitDetails (field mask)...");
+
+  // Dublin Airport → city centre: virtually always returns a bus step (issue #78 scope).
+  const result = await sendRequest(session, "tools/call", {
+    name: "maps_directions",
+    arguments: {
+      origin: "Dublin Airport, Ireland",
+      destination: "Trinity College Dublin, Ireland",
+      mode: "transit",
+    },
+  });
+  const content = result?.result?.content ?? [];
+  assert(content.length > 0, "Transit directions in Dublin returns content");
+  if (content.length === 0) return;
+
+  const text = content[0]?.text ?? "";
+  const isError = result?.result?.isError === true;
+  assert(!isError, `Transit directions in Dublin should succeed, got error: ${text.slice(0, 200)}`);
+  if (isError) return;
+
+  const parsed = JSON.parse(text);
+  const steps: any[] = parsed?.routes?.[0]?.legs?.flatMap((l: any) => l.steps ?? []) ?? [];
+  assert(steps.length > 0, "Transit response has at least one step");
+
+  const transitStep = steps.find((s: any) => s.transitDetails);
+  if (!transitStep) {
+    // Routes API may rarely return a walking-only itinerary; warn but don't flaky-fail.
+    console.log(
+      "  ⚠️  No transit step in this itinerary — field mask correctness cannot be asserted this run"
+    );
+    return;
+  }
+
+  const td = transitStep.transitDetails;
+  assert(
+    td?.transitLine || td?.stopDetails,
+    "transitDetails contains structured transit metadata (transitLine or stopDetails)",
+    `got: ${JSON.stringify(td).slice(0, 200)}`
+  );
+}
+
 // --------------- Main ---------------
 
 async function main() {
@@ -1127,6 +1174,7 @@ async function main() {
     await testToolCalls(session);
     await testPlaceDetailsPhotos(session);
     await testTransitErrorMessages(session);
+    await testTransitDetailsField(session);
     await testMultiSession();
   } catch (err) {
     console.error("\n💥 Fatal error:", err);


### PR DESCRIPTION
## Summary

Closes #78

The `COMPUTE_ROUTES_FIELD_MASK` in `src/services/RoutesService.ts` was missing `routes.legs.steps.transitDetails`, so transit steps returned only a free-text `navigationInstruction.instructions` (e.g. `"Bus towards Sean Moore Rd"`) without structured metadata — bus/route number, stop names, headsign, agency, stop count. Google Routes API only returns this object when explicitly requested via the `X-Goog-FieldMask` header.

This also resolves the symptom reported in [#74 (comment)](https://github.com/cablate/mcp-google-map/issues/74#issuecomment-4366688664) — "transit directions tell you to take a bus, but doesn't describe which one" — which shares the same root cause.

## Changes

| File | Change |
|------|--------|
| `src/services/RoutesService.ts` | Add `routes.legs.steps.transitDetails` to `COMPUTE_ROUTES_FIELD_MASK` |
| `tests/smoke.test.ts` | New `testTransitDetailsField`: assert transit step contains `transitDetails` with `transitLine`/`stopDetails` |

## Impact

- **Additive only.** The field is absent in non-transit steps, so driving/walking/bicycling responses are unchanged.
- **No schema or call-site changes.** `PlacesSearcher.getDirections` already passes `routes` through verbatim; `maps_directions` `ACTION` does `JSON.stringify(result.data)`, so the new object flows through untouched.
- **No effect on `computeRouteMatrix`** (distance matrix) — its field mask has no `steps` level.

## Test plan

- [x] `npm run build` succeeds
- [x] `npm run lint` — 0 errors (175 pre-existing warnings unchanged)
- [x] `npm test` — **198 passed, 0 failed**
- [x] Verified live API response: Dublin Airport → Trinity College Dublin returns a bus step with `transitDetails.{stopDetails, transitLine, headsign, stopCount, localizedValues}`

## Root cause verification

Independently called the Routes API with the new field mask:

```
Dublin Airport -> Trinity College Dublin: step[0] "Bus towards Dublin Airport Stops"
  transitDetails keys: stopDetails, localizedValues, headsign, transitLine, stopCount
```

The same field mask addition also restores structured transit metadata for Harold's Cross → Rathmines (the exact route in #78) and Paris → Lyon.